### PR TITLE
fix: Make default commit message ci friendly. If it includes language…

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -24,7 +24,7 @@ inputs:
   commit-message:
     description: 'commit message to use when pushing generated code'
     required: false
-    default: 'chore: injected tags into go structs [skip ci]'
+    default: 'chore: injected tags into go structs'
   checkout:
     description: 'set to true to checkout the repository, set to false if you are checking out the repository before using this action'
     required: false


### PR DESCRIPTION
… that causes ci to not run then it doesn't run even when things are squash merged, so it won't work at all.